### PR TITLE
fix(posts): set steamos post date to 2026-06-03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ src/resources/_gen
 *.tgz
 hugo-lyra-english.json
 .cache
+.playwright-cli/

--- a/src/content/posts/12-steamos-build/index.md
+++ b/src/content/posts/12-steamos-build/index.md
@@ -1,5 +1,5 @@
 +++
-date = "2026-06-04"
+date = "2026-06-03"
 title = "How I Built My Perfect Linux SteamOS Machine"
 slug = "linux-steamos-build"
 tags = ["linux", "hardware", "pc", "build", "gaming", "steamos", "cachyos"]


### PR DESCRIPTION
The SteamOS post was dated 2026-06-04, which Hugo treated as a future post and excluded from the build, so it did not appear on the live site. Setting the date to 2026-06-03 (a past date) so it publishes.

Also re-adds the `.playwright-cli/` entry to `.gitignore`, which did not make it into the previous merge.