### PR TITLE
fix(design): toggle url fragment, and the mobile menu

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -385,76 +385,51 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
       color: var(--ink-2);
     }
 
-    // The menu on a phone. The theme drives it with a checkbox and paints the
-    // open panel in its own colours, which do not exist here, so the panel is
-    // repainted as a plain list under a hairline.
+    // Two rows on a phone: the wordmark, then the links. Three short links do
+    // not need a disclosure, and the theme's menu added 260px of header to show
+    // them. There is no menu button any more.
+    //
+    // The theme hides the list off screen on narrow widths for that menu, so
+    // every part of that hiding has to be undone here.
     @media only screen and (max-width: 768px) {
       margin-bottom: 3.2rem;
 
       .container {
-        gap: 1.6rem;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.2rem;
         padding: 1.8rem 1.8rem;
       }
 
       .navigation-list {
-        display: block;
         position: static;
-        width: 100%;
-        margin: 1.6rem 0 0;
-        padding: 0;
-        max-height: 0;
-        overflow: hidden;
-        visibility: hidden;
-        opacity: 0;
-        background: none;
-        border: 0;
-        border-top: 1px solid var(--rule);
-        transition: opacity 0.2s ease, max-height 0.2s ease;
-      }
-
-      #menu-toggle:checked + label + .navigation-list {
+        display: flex;
         visibility: visible;
         opacity: 1;
-        max-height: 40rem;
+        max-height: none;
+        overflow: visible;
+        width: auto;
+        margin: 0;
+        padding: 0;
+        gap: 2.4rem;
+        background: none;
+        border: 0;
       }
 
       .navigation-item {
         float: none;
         text-align: left;
-        border-bottom: 1px solid var(--rule);
+        border: 0;
       }
 
       .navigation-link {
-        display: block;
+        display: inline;
         margin: 0;
-        padding: 1.3rem 0;
-        font-size: 1.9rem;
-        line-height: 1.3;
-      }
-
-      .menu-button {
-        font-size: 2.2rem;
-
-        i {
-          color: var(--ink-2);
-        }
-      }
-
-      #menu-toggle:checked + label > i {
-        color: var(--blush);
+        padding: 0;
+        font-size: 1.7rem;
+        line-height: 1.4;
       }
     }
-  }
-
-  // The wordmark stays on every page, because it anchors the left end of the
-  // bar and is the way back. On the home page the h1 repeats it a few
-  // centimetres below, so there it steps back to a quiet label instead of
-  // reading as a second headline. Browsers without :has() get the same wordmark
-  // everywhere, which is only a difference of weight.
-  &:has(.container.home) .navigation .navigation-title {
-    font-size: 1.7rem;
-    font-weight: 400;
-    color: var(--ink-3);
   }
 
   // ---------------------------------------------------------------------------

--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -2270,9 +2270,15 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
     border-radius: 2px;
   }
 
+  // A button rather than a link, so it needs the button chrome removed.
   .float-container .colorscheme-toggle {
-    color: var(--ink-3);
+    display: block;
+    padding: 0;
+    border: 0;
     background: none;
+    cursor: pointer;
+    color: var(--ink-3);
+    line-height: 0;
 
     &:hover,
     &:focus {

--- a/src/layouts/partials/float.html
+++ b/src/layouts/partials/float.html
@@ -1,17 +1,21 @@
 {{- /*
   Colour scheme toggle.
 
-  Inline SVG rather than a Font Awesome glyph, so no page has to download an
-  icon font to draw one control. The half filled circle is the same idea as the
-  theme's fa-adjust.
+  A button, not a link. It goes nowhere, and an anchor with href="#" appended a
+  fragment to the address bar on every click, because the theme's click handler
+  does not prevent the default navigation.
+
+  Inline SVG rather than a Font Awesome glyph, so no page downloads an icon font
+  to draw one control. The half filled circle is the same idea as the theme's
+  fa-adjust.
 */ -}}
 {{ if not .Site.Params.hideColorSchemeToggle }}
 <div class="float-container">
-  <a id="dark-mode-toggle" class="colorscheme-toggle" href="#" role="button" aria-label="{{ i18n "toggle_color_scheme" | default "Toggle the colour scheme" }}">
+  <button id="dark-mode-toggle" class="colorscheme-toggle" type="button" aria-label="{{ i18n "toggle_color_scheme" | default "Toggle the colour scheme" }}">
     <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true" focusable="false">
       <circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.6" />
       <path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor" />
     </svg>
-  </a>
+  </button>
 </div>
 {{ end }}

--- a/src/layouts/partials/header.html
+++ b/src/layouts/partials/header.html
@@ -1,9 +1,12 @@
 {{- /*
   Site header.
 
-  Copied from the theme for one change: the menu button is inline SVG rather
-  than a Font Awesome glyph. Together with the heading anchor and the colour
-  scheme toggle, that removes the last icon that could pull down the 155KB
+  Copied from the theme, without its menu button.
+
+  Three short links do not need a disclosure. Opening the theme's menu on a
+  phone added 260px of header and pushed the post down; the links now sit on a
+  second row, always visible, one tap instead of two. That also removes the
+  checkbox machinery and the last icon that could have pulled down the 155KB
   fa-solid face.
 */ -}}
 <nav class="navigation">
@@ -14,12 +17,6 @@
     </a>
     {{ end }}
     {{ if or .Site.Menus.main hugo.IsMultilingual }}
-      <input type="checkbox" id="menu-toggle" />
-      <label class="menu-button float-right" for="menu-toggle" aria-label="{{ i18n "menu" | default "Menu" }}">
-        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false">
-          <path d="M3 6h18M3 12h18M3 18h18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
-        </svg>
-      </label>
       <ul class="navigation-list">
         {{ with .Site.Menus.main}}
           {{ range sort . }}


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Two fixes to things #53 got wrong on the live site.

## The colour scheme toggle appended a fragment to the URL

Clicking light or dark turned `https://www.paolomainardi.com/` into `https://www.paolomainardi.com/#`.

Mine, from #53. Replacing the Font Awesome glyph with inline SVG, I wrote the control as an anchor with `href="#"` to make it keyboard reachable. The theme's click handler in `coder.js` does not call `preventDefault`, so the click ran the handler and then followed the link. The theme's original markup had no `href`, which is why this never happened before.

It is a `<button type="button">` now, which is what it always was: a control that goes nowhere. Keyboard activation with Enter and Space comes for free, and the address bar stays clean.

## The mobile menu was 260px of header for three links

Opening it added 260px to the header, with four hairlines, and pushed the post down. Three short links do not need a disclosure.

The header is two rows on narrow screens now, the wordmark and then the links, always visible. **101px, and one tap instead of two.** The checkbox and the menu button are gone from the markup entirely, which also removes the last of the theme's menu machinery.

One implementation note for review: the theme hides the navigation list off screen at narrow widths to drive that menu, using `position`, `visibility`, `opacity`, `max-height`, `overflow`, `width`, `background` and `border` together. All of them have to be undone explicitly. Missing any one leaves the links present in the DOM but invisible, which is exactly what happened on my first attempt.

## Verified on a 390 by 844 viewport

- Clicking the toggle no longer changes `location.href`. The scheme still switches and still persists to `localStorage`.
- The toggle is still keyboard focusable.
- Header is 101px, all three links visible, no horizontal overflow.
- `hugo --gc --minify` builds clean.