### PR TITLE
fix(design): restore the quiet wordmark on home, enlarge the mobile portrait

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -432,6 +432,17 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
     }
   }
 
+  // The wordmark stays on every page, because it anchors the left end of the bar
+  // and is the way back. On the home page the masthead repeats it a few
+  // centimetres below, so there it steps back to a quiet label instead of
+  // reading as a second headline. Browsers without :has() get the same wordmark
+  // everywhere, which is only a difference of weight.
+  &:has(.container.home) .navigation .navigation-title {
+    font-size: 1.7rem;
+    font-weight: 400;
+    color: var(--ink-3);
+  }
+
   // ---------------------------------------------------------------------------
   // 5. Footer
   // ---------------------------------------------------------------------------
@@ -482,9 +493,13 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
     // hairline and corner as the figures in a post.
     // Wider than the apparatus column it sits in, filling the margin and
     // leaving a 3rem gutter before the text.
+    // Scales with the viewport rather than sitting at a fixed size, so it is a
+    // photograph on a phone rather than an avatar, and still bounded on a
+    // tablet.
     .portrait {
       display: block;
-      width: 11rem;
+      width: 60%;
+      max-width: 24rem;
       height: auto;
       margin: 0 0 2rem;
       border: 1px solid var(--rule);


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Two fixes to the home page masthead. Neither made it into #55: the first was pushed to that branch after it had already been merged.

## The wordmark stopped being quiet on the home page

The header showed **19px semibold** "Paolo Mainardi" directly above the same words at **33px**, which is exactly the duplication that reads as a mistake rather than a running head.

The rule that steps it back on the home page was deleted by accident in #55. Rewriting the mobile navigation block replaced a range that ran from the block's opening comment to the next section header, and this rule was sitting in between. It went unnoticed because the regression is only visible on one page, in a place the eye skims.

It is back at 17px, regular weight, muted ink, so the header reads as a running head while the masthead keeps the name.

## The portrait was too small on a phone

110px on a 390px screen reads as an avatar rather than a photograph.

It now scales with the column rather than sitting at a fixed size: 60% of the width, capped at 240px. That gives **212px on a 390px phone** and keeps it bounded on a tablet, where a fixed percentage would have grown past the point of being a portrait.

## Note for review

The deletion in #55 is the second time a bulk text replacement in `custom.scss` has silently removed an adjacent rule. The file is now long enough that replacements should be anchored on both ends of the intended range, rather than on a section boundary that other rules can sit next to.

## Verified

- Home page at 390px, dark and light: wordmark 17px regular, heading 33px, portrait 212px.
- No horizontal overflow.
- `hugo --gc --minify` builds clean.