### PR TITLE
fix(design): align the portrait to the column, tidy the colophon on phones

### DIFF
--- a/src/assets/scss/custom.scss
+++ b/src/assets/scss/custom.scss
@@ -268,6 +268,12 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
     display: block;
     margin: 0;
     padding: 0 0 8rem;
+
+    // 8rem is breathing room at the end of a long post on a wide screen. On a
+    // phone it just leaves a hole between the last line and the footer.
+    @media only screen and (max-width: 768px) {
+      padding-bottom: 3.2rem;
+    }
   }
 
   .content > .container {
@@ -493,13 +499,12 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
     // hairline and corner as the figures in a post.
     // Wider than the apparatus column it sits in, filling the margin and
     // leaving a 3rem gutter before the text.
-    // Scales with the viewport rather than sitting at a fixed size, so it is a
-    // photograph on a phone rather than an avatar, and still bounded on a
-    // tablet.
+    // Full column width below 1200px, so its edges line up with the heading, the
+    // lede and every row beneath it. At a fixed width it sat 24px short of the
+    // name and read as a ragged edge.
     .portrait {
       display: block;
-      width: 60%;
-      max-width: 24rem;
+      width: 100%;
       height: auto;
       margin: 0 0 2rem;
       border: 1px solid var(--rule);
@@ -565,7 +570,12 @@ body:is(.colorscheme-light, .colorscheme-dark, .colorscheme-auto) {
   .colophon {
     display: flex;
     flex-wrap: wrap;
-    gap: 2.4rem;
+    gap: 1.6rem 2.4rem;
+
+    // A phone has no room for a 2.4rem gap between five items.
+    @media only screen and (max-width: 560px) {
+      gap: 1.4rem 1.8rem;
+    }
     max-width: var(--measure);
     margin: 5.6rem 0 0;
     // The left padding has to be zeroed explicitly, otherwise the list keeps

--- a/src/hugo.toml
+++ b/src/hugo.toml
@@ -68,7 +68,7 @@ custom_js = []
 
 # Social links
 [[params.social]]
-name = "RSS Feed"
+name = "RSS"
 icon = "fa fa-rss fa-2x"
 weight = 1
 url = "https://www.paolomainardi.com/posts/index.xml"
@@ -77,16 +77,6 @@ name = "Github"
 icon = "fa fa-github fa-2x"
 weight = 2
 url = "https://github.com/paolomainardi"
-[[params.social]]
-name = "Gitlab"
-icon = "fa fa-gitlab fa-2x"
-weight = 3
-url = "https://gitlab.com/paolomainardi"
-[[params.social]]
-name = "Twitter"
-icon = "fa fa-twitter fa-2x"
-weight = 4
-url = "https://twitter.com/paolomainardi"
 [[params.social]]
 name = "LinkedIn"
 icon = "fa fa-linkedin fa-2x"


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

Three small things on the home page, all visible on a phone.

## The portrait read as misaligned

Left edges matched exactly at 18px, but the image was **24px narrower than the heading below it**, and that ragged right edge is what the eye picked up.

It is full column width below 1200px now, so both edges line up with the heading, the lede, the section labels and every row beneath. 358px on a 394px phone.

## The colophon wrapped with an orphan

Four links wrapped to two rows with LinkedIn alone on the second. That is what flex wrapping does with items of unequal width, and tuning gaps against it would have broken again at another width or the next time a link was added.

- **GitLab and Twitter removed**, both unused.
- **"RSS Feed" becomes "RSS"**, since Feed was carrying nothing.
- Gap tightens below 560px.

Three items now fit one row at **360, 394 and 430px**, verified at each.

The `gitlab` and `twitter` paths stay in `partials/book/icon.html`. They are a lookup table, they are never fetched, and they are there if those links come back.

## A gap before the footer

`.content` carried `padding-bottom: 8rem`. That is breathing room after three thousand words on a wide screen, and a hole between the last line and the footer on a phone. It is `3.2rem` below 768px, unchanged above.

## Verified

- Colophon on one row at 360, 394 and 430px.
- Portrait edges match the text column exactly, 18px to 376px at 394px wide.
- Footer gap 80px to 32px on a phone.
- `hugo --gc --minify` builds clean.